### PR TITLE
Deck example

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Sensors/BMI088_Accelerometer.cs
+++ b/src/Emulator/Peripherals/Peripherals/Sensors/BMI088_Accelerometer.cs
@@ -72,7 +72,7 @@ namespace Antmicro.Renode.Peripherals.Sensors
 
         public byte[] Read(int count)
         {
-            if(registerAddress==Registers.AccXLSB)
+            if((registerAddress==Registers.AccXLSB) && (fifo.SamplesCount>0))
             {
                 fifo.TryDequeueNewSample();
             }

--- a/src/Emulator/Peripherals/Peripherals/Sensors/BMI088_Gyroscope.cs
+++ b/src/Emulator/Peripherals/Peripherals/Sensors/BMI088_Gyroscope.cs
@@ -86,7 +86,7 @@ namespace Antmicro.Renode.Peripherals.Sensors
 
         public byte[] Read(int count)
         {
-            if(registerAddress==Registers.RateXLSB)
+            if((registerAddress==Registers.RateXLSB) && (fifo.SamplesCount>0))
             {
                 fifo.TryDequeueNewSample();
             }


### PR DESCRIPTION
 - Allows the Syslink peripheral to return a simple message simulating the OneWire memory of the Flow deck v2.
 To enable, add `    deck: 1` (prefixed by four spaces) as an attribute of the nrf in [cf2.repl](https://github.com/bitcraze/renode/blob/crazyflie/platforms/boards/cf2.repl), i.e. below row 30.
For now, measurement data may be provided via Renode commands such as `sysbus.sram WriteWord` although minor changes in the firmware are needed in `flowdeck_v1v2.c` and `zranger2.c`, disabling the hardware interaction.

- The sensors now give the latest value if measurements are read when the queue is empty, otherwise they would return a zero vector. 